### PR TITLE
Add conventions page

### DIFF
--- a/CBView/2/API.md
+++ b/CBView/2/API.md
@@ -6,7 +6,7 @@ This section of the _Clipboard Component Component_ documentation focusses on de
 
 ## Supported Versions
 
-This documentation applies to v2.x only.
+~>2.0
 
 ## Contents
 
@@ -30,21 +30,7 @@ This documentation applies to v2.x only.
 
 ## Conventions
 
-Identifiers in plain text appear like this: _Identifier_
-
-Identifiers in links appear like this: [_Identifier_](#conventions)
-
-Values and in-line code appear like this:
-
-* `42`
-* `'text'`
-* `X := 42;`
-
-Declarations and source code examples appear syntax highlighted like this:
-
-```pascal
-procedure Foo(const Bar: string);
-```
+This documentation complies with [these conventions](/common/conventions.md).
 
 ## Links
 

--- a/CBView/2/API.md
+++ b/CBView/2/API.md
@@ -1,12 +1,10 @@
 # [Clipboard Viewer Component](../index.md) Programmers' Guide
 
+**Applies to:** ~>2.0
+
 ## Introduction
 
 This section of the _Clipboard Component Component_ documentation focusses on describing the usage of components's code.
-
-## Supported Versions
-
-~>2.0
 
 ## Contents
 

--- a/CBView/2/API/TPJCBViewer-Enabled.md
+++ b/CBView/2/API/TPJCBViewer-Enabled.md
@@ -6,7 +6,7 @@
 
 **Class:** [_TPJCBViewer_](./TPJCBViewer.md)
 
-**Applies to:** v2.x
+**Applies to:** ~>2.0
 
 ```pascal
 property Enabled: Boolean;

--- a/CBView/2/API/TPJCBViewer-OnClipboardChanged.md
+++ b/CBView/2/API/TPJCBViewer-OnClipboardChanged.md
@@ -6,7 +6,7 @@
 
 **Class:** [_TPJCBViewer_](./TPJCBViewer.md)
 
-**Applies to:** v2.x
+**Applies to:** ~>2.0
 
 ```pascal
 property OnClipboardChanged: TNotifyEvent;

--- a/CBView/2/API/TPJCBViewer-TriggerOnCreation.md
+++ b/CBView/2/API/TPJCBViewer-TriggerOnCreation.md
@@ -6,7 +6,7 @@
 
 **Class:** [_TPJCBViewer_](./TPJCBViewer.md)
 
-**Applies to:** v2.x
+**Applies to:** ~>2.0
 
 ```pascal
 property TriggerOnCreation: Boolean;

--- a/CBView/2/API/TPJCBViewer.md
+++ b/CBView/2/API/TPJCBViewer.md
@@ -4,7 +4,7 @@
 
 **Unit:** _PJCBView_
 
-**Applies to:** v2.x
+**Applies to:** ~>2.0
 
 _TPJCBViewer_ notifies the user of changes to the Windows clipboard. It registers itself with Windows to receive notifications whenever the contents of the clipboard change. When a change is detected the [_OnClipboardChanged_](./TPJCBViewer-OnClipboardChanged.md) event is triggered. Users handle this event.
 

--- a/common/conventions.md
+++ b/common/conventions.md
@@ -1,0 +1,38 @@
+# Conventions
+
+The following conventions are used in this documentation.
+
+## Identifiers
+
+Identifiers in plain text appear like this:
+
+* _Identifier_
+
+Identifiers in links appear like this:
+
+* [_Identifier_](#identifiers)
+
+## Values & In-line Code
+
+Values and in-line code appear like this:
+
+* `42`
+* `'text'`
+* `True`
+* `X := 42;`
+
+## Source Code Blocks
+
+Declarations and source code examples appear syntax highlighted like this:
+
+```pascal
+procedure Foo(const Bar: string);
+```
+
+## Version Numbers
+
+Some documentation pages apply only to a certain range of project versions. The applicable version numbers are specified using Ruby's [twiddle-wakka](https://thoughtbot.com/blog/rubys-pessimistic-operator) pessimistic operator. For example `~>3.2` means the documentation applies to all versions `>=3.2` and `<4.0`.
+
+## Links
+
+* [Home page](/index.md)


### PR DESCRIPTION
Add new page to describe various conventions used throughout the documentation.

Modify relevant pages to link here.

Modify content to comply as required.