### PR TITLE
Update TPJCBViewer project links on API pages

### DIFF
--- a/CBView/2/API/TPJCBViewer-Enabled.md
+++ b/CBView/2/API/TPJCBViewer-Enabled.md
@@ -1,6 +1,6 @@
 # Enabled property
 
-**Project:** [Clipboard Viewer Component](../../index.md)
+**Project:** [Clipboard Viewer Component](../API.md)
 
 **Unit:** _PJCBView_
 

--- a/CBView/2/API/TPJCBViewer-OnClipboardChanged.md
+++ b/CBView/2/API/TPJCBViewer-OnClipboardChanged.md
@@ -1,6 +1,6 @@
 # OnClipboardChanged event
 
-**Project:** [Clipboard Viewer Component](../../index.md)
+**Project:** [Clipboard Viewer Component](../API.md)
 
 **Unit:** _PJCBView_
 

--- a/CBView/2/API/TPJCBViewer-TriggerOnCreation.md
+++ b/CBView/2/API/TPJCBViewer-TriggerOnCreation.md
@@ -1,6 +1,6 @@
 # TriggerOnCreation property
 
-**Project:** [Clipboard Viewer Component](../../index.md)
+**Project:** [Clipboard Viewer Component](../API.md)
 
 **Unit:** _PJCBView_
 

--- a/CBView/2/API/TPJCBViewer.md
+++ b/CBView/2/API/TPJCBViewer.md
@@ -1,6 +1,6 @@
 # TPJCBViewer class
 
-**Project:** [Clipboard Viewer Component](../../index.md)
+**Project:** [Clipboard Viewer Component](../API.md)
 
 **Unit:** _PJCBView_
 


### PR DESCRIPTION
Change Project link to return to API page, not project home page.