### PR TITLE
Fix bad SASS header comments

### DIFF
--- a/_sass/_gh-highlighter-style.scss
+++ b/_sass/_gh-highlighter-style.scss
@@ -1,5 +1,5 @@
 /*! GitHub Pages default syntax highlighter. MIT License, github.com */
-
+/*! Generated with command `rougify style github > _gh-highlighter-style.scss` */
 .highlight table td { padding: 5px; }
 .highlight table pre { margin: 0; }
 .highlight .cm {

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -1,6 +1,5 @@
 /*! Main style sheet. Emulates GitHub Pages default style.
-*   Based on code from GitHub Pages obtained by doing
-*     rougify style github > style.css
+*   Based on code from GitHub Pages.
 *   MIT license, See https://delphidabbler.mit-license.org/ */
 
 * {


### PR DESCRIPTION
Remove erroneous comment about how original GitHub CSS was obtained