### PR TITLE
Create rouge highlighter documentation page

### DIFF
--- a/private/rouge-docs.md
+++ b/private/rouge-docs.md
@@ -1,0 +1,6 @@
+# Rouge Syntax Highlighter Documentation
+
+There is some useful info about the Rouge syntax highlighter on that project's wiki:
+
+* [List of supported languages](https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers)
+* [List of tokens](https://github.com/rouge-ruby/rouge/wiki/List-of-tokens) - provides names of the CSS classes associated with each token type.


### PR DESCRIPTION
Links to useful pages on Rouge wiki